### PR TITLE
Remove required property on the item_remove hidden checkbox

### DIFF
--- a/Resources/views/Form/fields.html.twig
+++ b/Resources/views/Form/fields.html.twig
@@ -57,6 +57,7 @@
                 // Uncheck remove input
                 item
                     .find('.idci_collection_item_remove')
+                    .prop('required', false)
                     .prop('checked', false)
                     .attr('checked', false)
                 ;


### PR DESCRIPTION
Since the last pull request from barbarian, we cannot submit more than one item due to the 'required' property on a hidden checkbox